### PR TITLE
Change CFP link for GitHub issues to filter to "cfp" label

### DIFF
--- a/routes/performers/index.md
+++ b/routes/performers/index.md
@@ -12,7 +12,7 @@ You can either comment on the current Call for Performers [issue on Github][1] o
 [send us an email][2]. Come chat with us on [Slack][3] (on the #wafflejs
 channel) if you want immediate feedback.
 
-[1]: https://github.com/wafflejs/wafflejs.github.io/issues
+[1]: https://github.com/wafflejs/wafflejs.github.io/issues?q=is%3Aopen+is%3Aissue+label%3Acfp
 [2]: mailto:perform@wafflejs.com
 [3]: https://borojs.slack.com/join/shared_invite/enQtMzM2Nzc5ODExNjY2LTUyNTg3OGMzMzhhNWU2OWViNWUxNmMyZjA5NmMzNGFhYmJkOWE5NzA4NWI5ZGY2NjdmNzBmYWJjMjYzZjkwOGE
 


### PR DESCRIPTION
I added a [label to the CFP issues](https://github.com/wafflejs/wafflejs.github.io/issues?q=is%3Aopen+is%3Aissue+label%3Acfp).